### PR TITLE
Add ONNX export and inference scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,37 @@ To evaluate the model and generate network inference file net_output.pickle, run
 python inference.py --config configs/exp/EuRoC/codenet.conf
 ```
 
+### Inference on a standalone IMU CSV
+
+If only the raw IMU measurements are available (timestamps, gyroscope and accelerometer) you can run the network directly on the CSV files listed in the dataset configuration without any ground‑truth orientation:
+
+```
+python csv_inference.py --config configs/exp/EuRoC/codenet.conf \
+                        --ckpt experiments/EuRoC/codenet/ckpt/best_model.ckpt
+```
+
+The script reads each sequence's `mav0/imu0/data.csv` based on `data_root` and `data_drive` entries in the config and writes `net_output.pickle` keyed by sequence name containing corrected IMU data (`corrected_acc`, `corrected_gyro` and `dt`).
+
+### Exporting to ONNX
+
+Convert a training checkpoint to both ONNX and a plain PyTorch state dictionary:
+
+```
+python export_onnx.py --config configs/exp/EuRoC/codenet.conf \
+                      --ckpt experiments/EuRoC/codenet/ckpt/best_model.ckpt \
+                      --onnx codenet.onnx --torch codenet.pt
+```
+
+### Offline inference with ONNX
+
+Run an exported ONNX model directly on the IMU CSV files listed in the config:
+
+```
+python onnx_inference.py --config configs/exp/EuRoC/codenet.conf --onnx codenet.onnx
+```
+
+The resulting `net_output.pickle` matches the format produced by `csv_inference.py` and can be consumed by the evaluation tools.
+
 <br>
 
 You can use the evaluation tool to assess your model performance with net_output.pickle， run the following command.

--- a/csv_inference.py
+++ b/csv_inference.py
@@ -1,0 +1,82 @@
+import argparse
+import os
+import pickle
+import numpy as np
+import torch
+from pyhocon import ConfigFactory
+
+from model import net_dict
+
+
+def load_imu_csv(csv_path: str):
+    """Load IMU data from a EuRoC-style CSV file."""
+    imu = np.loadtxt(csv_path, delimiter=",", dtype=float)
+    time = imu[:, 0] / 1e9  # ns -> s
+    gyro = imu[:, 1:4]
+    acc = imu[:, 4:7]
+    return time, acc, gyro
+
+
+def run(config: str, ckpt: str, device: str, outfile: str):
+    """Run inference on sequences specified in the config."""
+    # Load configuration and disable ground-truth orientation
+    conf = ConfigFactory.parse_file(config)
+    conf.train.gtrot = False
+    conf.train.device = device
+
+    # Build network and load weights
+    net = net_dict[conf.train.network](conf.train).to(device).double().eval()
+    checkpoint = torch.load(ckpt, map_location=device)
+    net.load_state_dict(checkpoint["model_state_dict"])
+
+    dataset_conf = conf.dataset.inference
+    results = {}
+
+    # Iterate over all sequences defined in the dataset config
+    for data_conf in dataset_conf.data_list:
+        root = data_conf["data_root"]
+        for seq in data_conf["data_drive"]:
+            csv_path = os.path.join(root, seq, "mav0", "imu0", "data.csv")
+            time, acc_all, gyro_all = load_imu_csv(csv_path)
+            dt = time[1:] - time[:-1]
+
+            # Drop last sample to match dt length
+            acc = acc_all[:-1]
+            gyro = gyro_all[:-1]
+
+            # Prepare batch tensors
+            acc_t = torch.tensor(acc, dtype=torch.float64).unsqueeze(0)
+            gyro_t = torch.tensor(gyro, dtype=torch.float64).unsqueeze(0)
+            batch = {"acc": acc_t, "gyro": gyro_t}
+
+            # Forward pass
+            with torch.no_grad():
+                out = net.inference(batch)
+                corrected_acc = acc_t[:, net.interval:, :] + out["correction_acc"]
+                corrected_gyro = gyro_t[:, net.interval:, :] + out["correction_gyro"]
+
+            # Align dt with corrected signals
+            dt_t = torch.tensor(dt[net.interval:], dtype=torch.float64)[:, None]
+
+            results[seq] = {
+                "correction_acc": out["correction_acc"][0],
+                "correction_gyro": out["correction_gyro"][0],
+                "corrected_acc": corrected_acc[0],
+                "corrected_gyro": corrected_gyro[0],
+                "dt": dt_t,
+            }
+
+    # Save results for downstream evaluation/integration
+    with open(outfile, "wb") as f:
+        pickle.dump(results, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run AirIMU on IMU CSVs listed in the config.")
+    parser.add_argument("--config", default="configs/exp/EuRoC/codenet.conf", help="Model config file")
+    parser.add_argument("--ckpt", default="experiments/EuRoC/codenet/ckpt/best_model.ckpt", help="Model checkpoint")
+    parser.add_argument("--device", default="cpu", help="Device to run on")
+    parser.add_argument("--out", default="net_output.pickle", help="Output pickle path")
+    args = parser.parse_args()
+
+    run(args.config, args.ckpt, args.device, args.out)

--- a/export_onnx.py
+++ b/export_onnx.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Export a trained AirIMU model to ONNX and plain PyTorch weights."""
+import argparse
+import torch
+from pyhocon import ConfigFactory
+from model import net_dict
+
+
+class CodeNetWrapper(torch.nn.Module):
+    """Wrapper removing dict inputs for ONNX export."""
+
+    def __init__(self, net: torch.nn.Module):
+        super().__init__()
+        self.net = net
+
+    def forward(self, acc: torch.Tensor, gyro: torch.Tensor):  # type: ignore[override]
+        out = self.net.inference({"acc": acc, "gyro": gyro})
+        return out["correction_acc"], out["correction_gyro"]
+
+
+def export(config: str, ckpt: str, onnx_path: str, torch_path: str,
+           seq_len: int, opset: int) -> None:
+    """Load a checkpoint and export to ONNX and PyTorch formats."""
+    conf = ConfigFactory.parse_file(config)
+    conf.train.gtrot = False
+    net = net_dict[conf.train.network](conf.train).double().eval()
+    state = torch.load(ckpt, map_location="cpu")
+    net.load_state_dict(state["model_state_dict"])
+
+    # Save plain PyTorch weights
+    torch.save(net.state_dict(), torch_path)
+
+    # Prepare dummy inputs (seq_len >= net.interval + 1)
+    L = max(seq_len, net.interval + 1)
+    acc = torch.zeros(1, L, 3, dtype=torch.float64)
+    gyro = torch.zeros(1, L, 3, dtype=torch.float64)
+
+    wrapper = CodeNetWrapper(net)
+    torch.onnx.export(
+        wrapper,
+        (acc, gyro),
+        onnx_path,
+        input_names=["acc", "gyro"],
+        output_names=["corr_acc", "corr_gyro"],
+        dynamic_axes={"acc": {1: "seq"}, "gyro": {1: "seq"},
+                      "corr_acc": {1: "seq"}, "corr_gyro": {1: "seq"}},
+        opset_version=opset,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export AirIMU checkpoint to ONNX")
+    parser.add_argument("--config", default="configs/exp/EuRoC/codenet.conf",
+                        help="Path to model config file")
+    parser.add_argument("--ckpt", default="experiments/EuRoC/codenet/ckpt/best_model.ckpt",
+                        help="Checkpoint file")
+    parser.add_argument("--onnx", default="codenet.onnx",
+                        help="Output ONNX file")
+    parser.add_argument("--torch", default="codenet.pt",
+                        help="Output PyTorch state_dict file")
+    parser.add_argument("--seq-len", type=int, default=1000,
+                        help="Dummy sequence length for export (>= interval+1)")
+    parser.add_argument("--opset", type=int, default=17, help="ONNX opset version")
+    args = parser.parse_args()
+
+    export(args.config, args.ckpt, args.onnx, args.torch, args.seq_len, args.opset)
+
+
+if __name__ == "__main__":
+    main()

--- a/onnx_inference.py
+++ b/onnx_inference.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Run offline inference using an exported ONNX AirIMU model."""
+import argparse
+import os
+import pickle
+import numpy as np
+import onnxruntime as ort
+from pyhocon import ConfigFactory
+from model import net_dict
+
+
+def load_imu_csv(csv_path: str):
+    imu = np.loadtxt(csv_path, delimiter=",", dtype=float)
+    time = imu[:, 0] / 1e9
+    gyro = imu[:, 1:4]
+    acc = imu[:, 4:7]
+    return time, acc, gyro
+
+
+def run(config: str, onnx_path: str, outfile: str) -> None:
+    conf = ConfigFactory.parse_file(config)
+    dataset_conf = conf.dataset.inference
+
+    # Instantiate network to obtain interval length
+    net = net_dict[conf.train.network](conf.train)
+    interval = getattr(net, "interval", 0)
+
+    sess = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+    results = {}
+
+    for data_conf in dataset_conf.data_list:
+        root = data_conf["data_root"]
+        for seq in data_conf["data_drive"]:
+            csv_path = os.path.join(root, seq, "mav0", "imu0", "data.csv")
+            time, acc_all, gyro_all = load_imu_csv(csv_path)
+            dt = time[1:] - time[:-1]
+            acc = acc_all[:-1]
+            gyro = gyro_all[:-1]
+
+            acc_np = acc[np.newaxis, ...]
+            gyro_np = gyro[np.newaxis, ...]
+            corr_acc, corr_gyro = sess.run(None, {"acc": acc_np, "gyro": gyro_np})
+            corrected_acc = acc_np[:, interval:, :] + corr_acc
+            corrected_gyro = gyro_np[:, interval:, :] + corr_gyro
+            dt_trimmed = dt[interval:, None]
+
+            results[seq] = {
+                "correction_acc": corr_acc[0],
+                "correction_gyro": corr_gyro[0],
+                "corrected_acc": corrected_acc[0],
+                "corrected_gyro": corrected_gyro[0],
+                "dt": dt_trimmed,
+            }
+
+    with open(outfile, "wb") as f:
+        pickle.dump(results, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run AirIMU ONNX model on IMU CSVs")
+    parser.add_argument("--config", default="configs/exp/EuRoC/codenet.conf",
+                        help="Model config file")
+    parser.add_argument("--onnx", default="codenet.onnx", help="ONNX model file")
+    parser.add_argument("--out", default="net_output.pickle", help="Output pickle")
+    args = parser.parse_args()
+
+    run(args.config, args.onnx, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ wandb==0.18.7
 pykitti
 pyproj
 opencv-python
+onnxruntime==1.20.0


### PR DESCRIPTION
## Summary
- add `export_onnx.py` to convert checkpoints to ONNX and plain PyTorch state dicts
- add `onnx_inference.py` to run exported ONNX models on CSV IMU data
- document ONNX export/inference workflow and add `onnxruntime` dependency

## Testing
- `python -m py_compile export_onnx.py onnx_inference.py`
- `python export_onnx.py --help`
- `python onnx_inference.py --help`
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68aa87b6ef44832c96c0cb8820e123d3