### PR TITLE
refactor: replace dict merges

### DIFF
--- a/datasets/dataset.py
+++ b/datasets/dataset.py
@@ -233,7 +233,10 @@ class SeqeuncesDataset(Data.Dataset):
             'gt_vel': self.gt_velo[seq_id][frame_id+1 : end_frame_id+1],
         }
 
-        return {**data, **init_state, **label}
+        out = dict(data)
+        out.update(init_state)
+        out.update(label)
+        return out
 
     def get_dtype(self):
         return self.acc[0].dtype

--- a/model/code.py
+++ b/model/code.py
@@ -127,8 +127,12 @@ class CodeNet(ModelBase):
 
         out_state = self.integrate(init_state = init_state, data = data, cov_state = inference_state['cov_state'])
 
-        return {**out_state, 'correction_acc': inference_state['correction_acc'], 'correction_gyro': inference_state['correction_gyro'], 
-                                'corrected_acc': data['corrected_acc'], 'corrected_gyro': data['corrected_gyro']}
+        out = dict(out_state)
+        out['correction_acc'] = inference_state['correction_acc']
+        out['correction_gyro'] = inference_state['correction_gyro']
+        out['corrected_acc'] = data['corrected_acc']
+        out['corrected_gyro'] = data['corrected_gyro']
+        return out
 
 
 class CodePoseNet(CodeNet):
@@ -210,7 +214,9 @@ class CodeNetKITTI(torch.nn.Module):
                 rot = gt_rot, 
             )
         
-        return {**out_state, **cov_state}
+        out = dict(out_state)
+        out.update(cov_state)
+        return out
 
     def inference(self, data):
         feature_acc  = self.accEncoder(data["acc"].transpose(-1,-2)).transpose(-1,-2)
@@ -240,10 +246,9 @@ class CodeNetKITTI(torch.nn.Module):
 
         out_state = self.integrate(init_state=init_state_, data = data, cov_state = inference_state['cov_state'], use_gtrot=use_gtrot)
         
-        return {
-            **out_state, 
-            'correction_acc': inference_state['correction_acc'], 
-            'correction_gyro': inference_state['correction_gyro'], 
-            'corrected_acc': data['corrected_acc'], 
-            'corrected_gyro': data['corrected_gyro']
-        }
+        out = dict(out_state)
+        out['correction_acc'] = inference_state['correction_acc']
+        out['correction_gyro'] = inference_state['correction_gyro']
+        out['corrected_acc'] = data['corrected_acc']
+        out['corrected_gyro'] = data['corrected_gyro']
+        return out

--- a/model/net.py
+++ b/model/net.py
@@ -75,7 +75,9 @@ class ModelBase(nn.Module):
             out_state = self.integrator(init_state = init_state, dt = data['dt'], gyro = data['corrected_gyro'],
                             acc = data['corrected_acc'], rot = gt_rot, acc_cov = cov_state['acc_cov'], gyro_cov = cov_state['gyro_cov'])
         
-        return {**out_state, **cov_state}
+        out = dict(out_state)
+        out.update(cov_state)
+        return out
 
     def inference(self, data):
         '''
@@ -95,7 +97,10 @@ class ModelBase(nn.Module):
             cov = self.cov_decoder(feature)
             cov_state['acc_cov'] = cov[...,:3]; cov_state['gyro_cov'] = cov[...,3:]
 
-        return {**cov_state, 'correction_acc': correction[...,:3], 'correction_gyro': correction[...,3:]}
+        out = dict(cov_state)
+        out['correction_acc'] = correction[...,:3]
+        out['correction_gyro'] = correction[...,3:]
+        return out
  
     ## For reference
     def forward(self, data, init_state):
@@ -114,4 +119,7 @@ class ModelBase(nn.Module):
             cov_state['acc_cov'] = cov[...,:3]; cov_state['gyro_cov'] = cov[...,3:]
 
         out_state = self.integrate(init_state = init_state, data = data, cov_state = cov_state)
-        return {**out_state, 'correction_acc': correction[...,:3], 'correction_gyro': correction[...,3:]}
+        out = dict(out_state)
+        out['correction_acc'] = correction[...,:3]
+        out['correction_gyro'] = correction[...,3:]
+        return out

--- a/model/others.py
+++ b/model/others.py
@@ -41,4 +41,7 @@ class ParamNet(ModelBase):
             cov_state['gyro_cov'] = torch.zeros_like(data['corrected_gyro']) + self.gyro_cov**2
 
         out_state = self.integrate(init_state = init_state, data = data, cov_state = cov_state)
-        return {**out_state, 'correction_acc': self.acc_bias, 'correction_gyro': self.gyro_bias}
+        out = dict(out_state)
+        out['correction_acc'] = self.acc_bias
+        out['correction_gyro'] = self.gyro_bias
+        return out


### PR DESCRIPTION
## Summary
- eliminate use of `{**...}` dict merging in data loaders and model components
- build result dictionaries explicitly via `out = dict(source)` updates

## Testing
- `python export_onnx.py --config configs/exp/EuRoC/codenet.conf --ckpt dummy.ckpt --onnx /tmp/airimu20.onnx --torch /tmp/airimu20.pt --seq-len 20`
- `python export_onnx.py --config configs/exp/EuRoC/codenet.conf --ckpt dummy.ckpt --onnx /tmp/airimu50.onnx --torch /tmp/airimu50.pt --seq-len 50`


------
https://chatgpt.com/codex/tasks/task_e_68b263c8c304832ca94c2deae77292d2